### PR TITLE
Initialized for supporting HTTP/2 protocol.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,8 @@ tokio = {  version = "1.47.0", features = ["macros", "rt-multi-thread", "net", "
 tokio-stream = { version = "0.1.17", default-features = false, features = ["net"] }
 tokio-util = { version = "0.7.15", features = ["io"]}
 chrono = "0.4.42"
+
+# Http2
+fluke-hpack = "0.3.1"
+fluke-h2-parse = "0.1.1"
+fluke-buffet = "0.2.0"

--- a/README.md
+++ b/README.md
@@ -19,3 +19,15 @@ $ curl
 
 
 ```
+
+
+### HTTP/2
+```shell
+$ brew install h2spec
+$ cd http_h2
+$ python main.py
+...
+
+$ h2spec -p 8080 -h localhost -P /hello
+$ h2spec -p 8080 -h localhost -P /hello generic/1  
+```

--- a/src/frame_handler.rs
+++ b/src/frame_handler.rs
@@ -1,0 +1,130 @@
+use bytes::Bytes;
+use fluke_h2_parse::{
+    preface,
+    Frame,
+    FrameType,
+    FrameType::Settings,
+    SettingsFlags,
+    StreamId
+};
+use fluke_h2_parse::enumflags2::BitFlags;
+use fluke_hpack::{
+    Decoder,
+    Encoder
+};
+
+pub struct FrameHandle {
+
+}
+
+impl FrameHandle {
+
+    pub fn new() -> Self {
+        FrameHandle {}
+    }
+
+    pub async fn handle(&self, frame: &Frame) -> anyhow::Result<()>{
+        match frame.frame_type {
+            Settings(_) => {
+                SettingsFrameHandler::new()
+                    .handle(frame)
+                    .await
+            },
+            _ => {
+                println!("hello2");
+                Ok(())
+            }
+        }
+    }
+}
+
+
+
+trait FrameHandler {
+
+    async fn handle(&self, frame: &Frame) -> anyhow::Result<()> {
+        self.validate(&frame).await?;
+        self.process(&frame).await?;
+        self.maybe_ack(&frame).await?;
+        Ok(())
+    }
+    async fn validate(&self, frame: &Frame) -> anyhow::Result<()>;
+    async fn maybe_ack(&self, frame: &Frame) -> anyhow::Result<()>;
+    async fn process(&self, frame: &Frame) -> anyhow::Result<()>;
+
+}
+
+
+struct SettingsFrameHandler { }
+
+impl SettingsFrameHandler {
+    pub fn new() -> Self {
+        SettingsFrameHandler {}
+    }
+}
+
+
+impl FrameHandler for SettingsFrameHandler {
+
+    // RFC : https://datatracker.ietf.org/doc/html/rfc7540#section-6.5
+
+    async fn validate(&self, frame: &Frame) -> anyhow::Result<()>{
+        Ok(())
+    }
+
+    async fn maybe_ack(&self, frame: &Frame) -> anyhow::Result<()> {
+        let ack_frame = Frame::new(Settings(BitFlags::from(SettingsFlags::Ack)), StreamId(0));
+        let hello = h2_frame_to_bytes(ack_frame, &[]);
+        Ok(())
+    }
+
+    async fn process(&self, frame: &Frame) -> anyhow::Result<()> {
+        Ok(())
+    }
+}
+
+
+
+
+// 공용 헬퍼: 9바이트 헤더 + payload 쓰기
+// TODO : 나중에 공부하기.
+fn h2_frame_to_bytes(
+    frame: Frame,
+    // frame_type: u8,   // SETTINGS=0x04
+    // flags: u8,        // ACK=0x01
+    // stream_id: u32,   // SETTINGS는 0
+    payload: &[u8],   // ACK는 빈 페이로드
+) -> anyhow::Result<Bytes> {
+
+
+
+    let frame_type_byte = match frame.frame_type {
+        Settings(_) => 0x04,
+        _ => 0x01
+    };
+
+    let flags = match frame.frame_type {
+        Settings(flags) => flags.bits(),
+        _ => 0x01,
+    };
+
+    let sid  = frame.stream_id.0 & 0x7FFF_FFFF;
+    let len = payload.len();
+    let mut hdr = [0u8; 9];
+
+    // length (24-bit, big-endian)
+    hdr[0] = ((len >> 16) & 0xFF) as u8;
+    hdr[1] = ((len >> 8)  & 0xFF) as u8;
+    hdr[2] = ( len        & 0xFF) as u8;
+
+    hdr[3] = frame_type_byte;// type
+    hdr[4] = flags;          // flags
+
+    // let sid = stream_id & 0x7FFF_FFFF; // R 비트 0
+    hdr[5] = ((sid >> 24) & 0xFF) as u8;
+    hdr[6] = ((sid >> 16) & 0xFF) as u8;
+    hdr[7] = ((sid >> 8)  & 0xFF) as u8;
+    hdr[8] = ( sid        & 0xFF) as u8;
+
+    Ok(Bytes::copy_from_slice(&hdr))
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ mod parse_header;
 mod http_connection_context;
 mod http_request_context;
 mod http_11_headers;
+mod frame_handler;
 
 use anyhow::Result;
 use crate::http_type::{Method};


### PR DESCRIPTION
### Changes
- HTTP/2 protocol 지원을 위한 기초적인 백본 프레임 구축 중
- 구조 변경 고려 필요. 현재는 owner 레벨까지 내려가야 처리가 가능한데, HTTP/2를 지원하기 위한 구조에는 적합하지 않은 듯. (Writer를 쓸 수 없기 때문임) 
- Header 역직렬화 및 프레임 헤더 / payload 확인 필요. 